### PR TITLE
Added support for Shadow Root through css selector

### DIFF
--- a/apps/acf-extension/src/content_scripts/common.ts
+++ b/apps/acf-extension/src/content_scripts/common.ts
@@ -23,6 +23,18 @@ const Common = (() => {
         elements = element ? [element] : undefined;
       } else if (/^Selector::/gi.test(elementFinder)) {
         const element = document.querySelector<HTMLElement>(elementFinder.replace(/^Selector::/gi, ''));
+        if (!element) {
+          const shadowHosts = document.querySelectorAll('*');
+          for (const shadowHost of shadowHosts) {
+            if (shadowHost.shadowRoot) {
+              const shadowElement = shadowHost.shadowRoot.querySelector<HTMLElement>(elementFinder.replace(/^Selector::/gi, ''));
+              if (shadowElement) {
+                elements = [shadowElement];
+                break;
+              }
+            }
+          }
+        }
         elements = element ? [element] : undefined;
       } else if (/^ClassName::/gi.test(elementFinder)) {
         const classElements = document.getElementsByClassName(elementFinder.replace(/^ClassName::/gi, '')) as HTMLCollectionOf<HTMLElement>;

--- a/apps/acf-extension/src/wizard/store/slice.ts
+++ b/apps/acf-extension/src/wizard/store/slice.ts
@@ -42,8 +42,8 @@ const slice = createSlice({
       });
 
       if (state.timer) {
-        const initWait = (new Date().getTime() - state.timer) / 1000;
-        action.payload.initWait = initWait < 5 ? 0 : 5;
+        //const initWait = (new Date().getTime() - state.timer) / 1000;
+        action.payload.initWait = 0; //initWait < 5 ? 0 : 5;
       }
       state.timer = new Date().getTime();
 


### PR DESCRIPTION
# Description

This pull request includes changes to improve element selection within shadow DOMs and simplifies timer initialization logic in the `acf-extension` application.

Improvements to element selection:

* [`apps/acf-extension/src/content_scripts/common.ts`](diffhunk://#diff-203db2f1bbf3660ab26a901a95aba5460642ff5673e3131060b0677d03549c94R26-R37): Added logic to search for elements within shadow DOMs when using the `Selector::` prefix.

Simplifications to timer initialization:

* [`apps/acf-extension/src/wizard/store/slice.ts`](diffhunk://#diff-f13b81805f308449efd54573ebb1c6abeb138594d3364f7f2de2b958d64d94f0L45-R46): Simplified the timer initialization logic by setting `initWait` to 0 directly, removing the conditional calculation.
* 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code (E2E)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (DOCS)
- [ ] I have made corresponding changes to the blog (BLOG)
- [ ] My changes generate no new warnings (SONAR)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Create video on functionality
- [ ] Any dependent changes have been merged and published in downstream modules
