### PR TITLE
Refactor event handling to work on iframe element which don't have src

### DIFF
--- a/libs/acf/events/src/lib/append.events.ts
+++ b/libs/acf/events/src/lib/append.events.ts
@@ -7,7 +7,8 @@ import CommonEvents, { UNKNOWN_ELEMENT_TYPE_ERROR } from './common.events';
 const CHANGE_EVENT = ['input', 'change'];
 export const AppendEvents = (() => {
   const checkNode = (element: HTMLElement, value: string) => {
-    if (element instanceof HTMLTextAreaElement || (element instanceof HTMLInputElement && !RADIO_CHECKBOX_NODE_NAME.test(element.type))) {
+    const eW = CommonEvents.getElementWindow(element);
+    if (element instanceof eW.HTMLTextAreaElement || (element instanceof eW.HTMLInputElement && !RADIO_CHECKBOX_NODE_NAME.test(element.type))) {
       element.value += value;
       element.dispatchEvent(CommonEvents.getFillEvent());
     } else if (element.isContentEditable) {

--- a/libs/acf/events/src/lib/clipboard.events.ts
+++ b/libs/acf/events/src/lib/clipboard.events.ts
@@ -20,7 +20,8 @@ export const ClipboardEvents = (() => {
   };
 
   const getValue = (element: HTMLElement) => {
-    if (element instanceof HTMLSelectElement || element instanceof HTMLTextAreaElement || (element instanceof HTMLInputElement && !RADIO_CHECKBOX_NODE_NAME.test(element.type))) {
+    const eW = CommonEvents.getElementWindow(element);
+    if (element instanceof eW.HTMLSelectElement || element instanceof eW.HTMLTextAreaElement || (element instanceof eW.HTMLInputElement && !RADIO_CHECKBOX_NODE_NAME.test(element.type))) {
       return element.value;
     }
     if (element.isContentEditable) {
@@ -31,7 +32,8 @@ export const ClipboardEvents = (() => {
   };
 
   const checkNode = (element: HTMLElement, value: string) => {
-    if (element instanceof HTMLSelectElement || element instanceof HTMLTextAreaElement || (element instanceof HTMLInputElement && !RADIO_CHECKBOX_NODE_NAME.test(element.type))) {
+    const eW = CommonEvents.getElementWindow(element);
+    if (element instanceof eW.HTMLSelectElement || element instanceof eW.HTMLTextAreaElement || (element instanceof eW.HTMLInputElement && !RADIO_CHECKBOX_NODE_NAME.test(element.type))) {
       element.value = value;
       element.dispatchEvent(CommonEvents.getFillEvent());
     } else if (element.isContentEditable) {

--- a/libs/acf/events/src/lib/common.events.ts
+++ b/libs/acf/events/src/lib/common.events.ts
@@ -100,7 +100,11 @@ const CommonEvents = (() => {
     which = 0,
   }): KeyboardEventInit => ({ key, code, location, ctrlKey, shiftKey, altKey, metaKey, bubbles, repeat, isComposing, charCode, keyCode, which });
 
-  return { getFillEvent, getMouseEvent, getMouseEventProperties, getKeyboardEventProperties, loopElements, getVerifiedEvents, getTouchEvent, getTouchEventProperties, getTouch };
+  const getElementWindow = (element: HTMLElement): Window & typeof globalThis => {
+    return element.ownerDocument.defaultView || window;
+  };
+
+  return { getFillEvent, getElementWindow, getMouseEvent, getMouseEventProperties, getKeyboardEventProperties, loopElements, getVerifiedEvents, getTouchEvent, getTouchEventProperties, getTouch };
 })();
 
 export const EVENTS = {

--- a/libs/acf/events/src/lib/copy.events.ts
+++ b/libs/acf/events/src/lib/copy.events.ts
@@ -1,6 +1,7 @@
 import { RADIO_CHECKBOX_NODE_NAME } from '@dhruv-techapps/acf-common';
 import { GoogleAnalyticsService } from '@dhruv-techapps/google-analytics';
 import { ACTION_I18N_TITLE } from '.';
+import CommonEvents from './common.events';
 
 const LOCAL_STORAGE_COPY = 'auto-clicker-copy';
 
@@ -16,7 +17,8 @@ export const CopyEvents = (() => {
   };
 
   const getValue = (element: HTMLElement) => {
-    if (element instanceof HTMLSelectElement || element instanceof HTMLTextAreaElement || (element instanceof HTMLInputElement && !RADIO_CHECKBOX_NODE_NAME.test(element.type))) {
+    const eW = CommonEvents.getElementWindow(element);
+    if (element instanceof eW.HTMLSelectElement || element instanceof eW.HTMLTextAreaElement || (element instanceof eW.HTMLInputElement && !RADIO_CHECKBOX_NODE_NAME.test(element.type))) {
       return element.value;
     }
     if (element.isContentEditable) {

--- a/libs/acf/events/src/lib/form.events.ts
+++ b/libs/acf/events/src/lib/form.events.ts
@@ -6,7 +6,8 @@ const FORM_EVENTS = ['blur', 'click', 'click-once', 'focus', 'select', 'submit',
 
 export const FormEvents = (() => {
   const dispatchEvent = (element: HTMLElement, events: Array<string | Event>) => {
-    if (!(element instanceof HTMLElement)) {
+    const eW = CommonEvents.getElementWindow(element);
+    if (!(element instanceof eW.HTMLElement)) {
       throw new ConfigError(`elementFinder: ${element}`, 'Not HTMLElement');
     }
     events.forEach((event) => {
@@ -26,17 +27,17 @@ export const FormEvents = (() => {
           element.focus();
           break;
         case 'submit':
-          if (element instanceof HTMLFormElement) {
+          if (element instanceof eW.HTMLFormElement) {
             element.submit();
           } else if (
-            element instanceof HTMLSelectElement ||
-            element instanceof HTMLTextAreaElement ||
-            element instanceof HTMLInputElement ||
-            element instanceof HTMLButtonElement ||
-            element instanceof HTMLLabelElement ||
-            element instanceof HTMLOptionElement ||
-            element instanceof HTMLFieldSetElement ||
-            element instanceof HTMLOutputElement
+            element instanceof eW.HTMLSelectElement ||
+            element instanceof eW.HTMLTextAreaElement ||
+            element instanceof eW.HTMLInputElement ||
+            element instanceof eW.HTMLButtonElement ||
+            element instanceof eW.HTMLLabelElement ||
+            element instanceof eW.HTMLOptionElement ||
+            element instanceof eW.HTMLFieldSetElement ||
+            element instanceof eW.HTMLOutputElement
           ) {
             element.form?.submit();
           } else {
@@ -45,7 +46,7 @@ export const FormEvents = (() => {
           }
           break;
         case 'select':
-          if (element instanceof HTMLTextAreaElement || element instanceof HTMLInputElement) {
+          if (element instanceof eW.HTMLTextAreaElement || element instanceof eW.HTMLInputElement) {
             element.select();
           }
           break;
@@ -53,7 +54,7 @@ export const FormEvents = (() => {
           element.remove();
           break;
         case 'clear':
-          if (element instanceof HTMLSelectElement || element instanceof HTMLTextAreaElement || element instanceof HTMLInputElement) {
+          if (element instanceof eW.HTMLSelectElement || element instanceof eW.HTMLTextAreaElement || element instanceof eW.HTMLInputElement) {
             element.value = '';
           } else {
             console.error(element);

--- a/libs/acf/events/src/lib/func.events.ts
+++ b/libs/acf/events/src/lib/func.events.ts
@@ -9,7 +9,8 @@ const CHANGE_EVENT = ['input', 'change'];
 
 export const FuncEvents = (() => {
   const checkNode = (element: HTMLElement, value: string) => {
-    if (element instanceof HTMLSelectElement || element instanceof HTMLTextAreaElement || (element instanceof HTMLInputElement && !RADIO_CHECKBOX_NODE_NAME.test(element.type))) {
+    const eW = CommonEvents.getElementWindow(element);
+    if (element instanceof eW.HTMLSelectElement || element instanceof eW.HTMLTextAreaElement || (element instanceof eW.HTMLInputElement && !RADIO_CHECKBOX_NODE_NAME.test(element.type))) {
       element.value = value;
       element.dispatchEvent(CommonEvents.getFillEvent());
     } else if (element.isContentEditable) {

--- a/libs/acf/events/src/lib/index.ts
+++ b/libs/acf/events/src/lib/index.ts
@@ -89,7 +89,7 @@ export const Events = (() => {
           await ClipboardEvents.start(elements, value);
           break;
         case EVENTS.ELEMENT:
-          await ElementEvents.start(elements, value);
+          ElementEvents.start(elements, value);
           break;
         default:
           PlainEvents.start(elements, value);

--- a/libs/acf/events/src/lib/key.events.ts
+++ b/libs/acf/events/src/lib/key.events.ts
@@ -36,7 +36,8 @@ export const KeyEvents = (() => {
   };
 
   const dispatchEvent = async (element: HTMLElement, events: Array<KeyEvent>) => {
-    if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) {
+    const eW = CommonEvents.getElementWindow(element); // Get eW
+    if (element instanceof eW.HTMLInputElement || element instanceof eW.HTMLTextAreaElement) {
       // eslint-disable-next-line no-restricted-syntax
       for (const event of events) {
         element.dispatchEvent(new KeyboardEvent(KEYBOARD_EVENT_KEYDOWN, event));

--- a/libs/acf/events/src/lib/paste.events.ts
+++ b/libs/acf/events/src/lib/paste.events.ts
@@ -10,7 +10,8 @@ const CHANGE_EVENT = ['input', 'change'];
 
 export const PasteEvents = (() => {
   const checkNode = (element: HTMLElement, value: string) => {
-    if (element instanceof HTMLSelectElement || element instanceof HTMLTextAreaElement || (element instanceof HTMLInputElement && !RADIO_CHECKBOX_NODE_NAME.test(element.type))) {
+    const eW = CommonEvents.getElementWindow(element);
+    if (element instanceof eW.HTMLSelectElement || element instanceof eW.HTMLTextAreaElement || (element instanceof eW.HTMLInputElement && !RADIO_CHECKBOX_NODE_NAME.test(element.type))) {
       element.value = value;
       element.dispatchEvent(CommonEvents.getFillEvent());
     } else if (element.isContentEditable) {

--- a/libs/acf/events/src/lib/plain.events.ts
+++ b/libs/acf/events/src/lib/plain.events.ts
@@ -11,7 +11,8 @@ export const PlainEvents = (() => {
   const checkEmptyValue = (value: string) => (value === '::empty' ? '' : value);
 
   const dispatchEvent = (element: HTMLElement, value: string) => {
-    if (element instanceof HTMLSelectElement) {
+    const eW = CommonEvents.getElementWindow(element);
+    if (element instanceof eW.HTMLSelectElement) {
       const nodes = document.evaluate(
         `.//option[text()="${value}" or contains(text(),"${value}") or @value="${value}" or @id="${value}"]`,
         element,
@@ -22,10 +23,10 @@ export const PlainEvents = (() => {
       if (nodes.snapshotLength !== 0) {
         (nodes.snapshotItem(0) as HTMLOptionElement).selected = true;
       }
-    } else if (element instanceof HTMLTextAreaElement || (element instanceof HTMLInputElement && !RADIO_CHECKBOX_NODE_NAME.test(element.type))) {
+    } else if (element instanceof eW.HTMLTextAreaElement || (element instanceof eW.HTMLInputElement && !RADIO_CHECKBOX_NODE_NAME.test(element.type))) {
       element.value = value;
       element.dispatchEvent(CommonEvents.getFillEvent());
-    } else if (element instanceof HTMLOptionElement) {
+    } else if (element instanceof eW.HTMLOptionElement) {
       element.selected = true;
     } else if (element.isContentEditable) {
       GoogleAnalyticsService.fireEvent('isContentEditable', { event: 'PlainEvents' });

--- a/libs/acf/events/src/lib/prepend.events.ts
+++ b/libs/acf/events/src/lib/prepend.events.ts
@@ -8,7 +8,8 @@ const CHANGE_EVENT = ['input', 'change'];
 
 export const PrependEvents = (() => {
   const checkNode = (element: HTMLElement, value: string) => {
-    if (element instanceof HTMLSelectElement || element instanceof HTMLTextAreaElement || (element instanceof HTMLInputElement && !RADIO_CHECKBOX_NODE_NAME.test(element.type))) {
+    const eW = CommonEvents.getElementWindow(element);
+    if (element instanceof eW.HTMLSelectElement || element instanceof eW.HTMLTextAreaElement || (element instanceof eW.HTMLInputElement && !RADIO_CHECKBOX_NODE_NAME.test(element.type))) {
       element.value = value + element.value;
       element.dispatchEvent(CommonEvents.getFillEvent());
     } else if (element.isContentEditable) {

--- a/libs/acf/events/src/lib/replace.events.ts
+++ b/libs/acf/events/src/lib/replace.events.ts
@@ -9,7 +9,8 @@ const CHANGE_EVENT = ['input', 'change'];
 export const ReplaceEvents = (() => {
   const checkNode = (element: HTMLElement, value: string) => {
     const [target, string] = value.split('::');
-    if (element instanceof HTMLSelectElement || element instanceof HTMLTextAreaElement || (element instanceof HTMLInputElement && !RADIO_CHECKBOX_NODE_NAME.test(element.type))) {
+    const eW = CommonEvents.getElementWindow(element);
+    if (element instanceof eW.HTMLSelectElement || element instanceof eW.HTMLTextAreaElement || (element instanceof eW.HTMLInputElement && !RADIO_CHECKBOX_NODE_NAME.test(element.type))) {
       element.value = element.value.replace(new RegExp(target, 'g'), string);
       element.dispatchEvent(CommonEvents.getFillEvent());
     } else if (element.isContentEditable) {


### PR DESCRIPTION
…element type checks

# Description

This pull request introduces a new utility function `getElementWindow` to standardize how the window object is retrieved for various HTML elements across multiple event handling modules. The most important changes include the addition of this function in `common.events.ts` and its integration into various event modules.

### Introduction of `getElementWindow` function:
* [`libs/acf/events/src/lib/common.events.ts`](diffhunk://#diff-67075c561007b6b69c5b720ebb74e6b7cf6d7c80303085adcb19af3c608916b6L103-R107): Added `getElementWindow` function to retrieve the window object associated with an element.

### Integration of `getElementWindow` function:
* [`libs/acf/events/src/lib/append.events.ts`](diffhunk://#diff-622dd5b2dd0766d9ccfc40a4636c22eb323cfcdab2ab6d7690c833f632ea0340L10-R11): Updated `checkNode` function to use `getElementWindow` for `HTMLTextAreaElement` and `HTMLInputElement` checks.
* [`libs/acf/events/src/lib/clipboard.events.ts`](diffhunk://#diff-14cc25836fc21d0c87942c7cfbd4262669fc4550d30afb0672add9437a4e153aL23-R24): Updated `getValue` and `checkNode` functions to use `getElementWindow` for various element type checks. [[1]](diffhunk://#diff-14cc25836fc21d0c87942c7cfbd4262669fc4550d30afb0672add9437a4e153aL23-R24) [[2]](diffhunk://#diff-14cc25836fc21d0c87942c7cfbd4262669fc4550d30afb0672add9437a4e153aL34-R36)
* [`libs/acf/events/src/lib/copy.events.ts`](diffhunk://#diff-5ba9c4b3914bf0e1710ded21ada15e97e1f3e786ac0e7e77ae77ef44102795c9L19-R21): Updated `getValue` function to use `getElementWindow` for various element type checks.
* [`libs/acf/events/src/lib/form.events.ts`](diffhunk://#diff-b0233c3eaf4b328fb400cff07aef8d97537fbea84b7f12572be1a8f9aece7bddL9-R10): Updated `dispatchEvent`, `submit`, `select`, and `clear` functions to use `getElementWindow` for various element type checks. [[1]](diffhunk://#diff-b0233c3eaf4b328fb400cff07aef8d97537fbea84b7f12572be1a8f9aece7bddL9-R10) [[2]](diffhunk://#diff-b0233c3eaf4b328fb400cff07aef8d97537fbea84b7f12572be1a8f9aece7bddL29-R40) [[3]](diffhunk://#diff-b0233c3eaf4b328fb400cff07aef8d97537fbea84b7f12572be1a8f9aece7bddL48-R57)

### Other changes:
* [`libs/acf/events/src/lib/index.ts`](diffhunk://#diff-4949c65b8312948d6693b06189e19acb8e046a425e1274a49bf2fc019312d3a7L92-R92): Removed `await` keyword from `ElementEvents.start` call.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code (E2E)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (DOCS)
- [ ] I have made corresponding changes to the blog (BLOG)
- [ ] My changes generate no new warnings (SONAR)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Create video on functionality
- [ ] Any dependent changes have been merged and published in downstream modules
