### PR TITLE
Potential fix for code scanning alert no. 1443: Incomplete regular expression for hostnames

### DIFF
--- a/apps/acf-options-page/src/components/ads.components.tsx
+++ b/apps/acf-options-page/src/components/ads.components.tsx
@@ -4,7 +4,7 @@ import { GoogleAds } from './google-ads.components';
 
 export function Ads() {
   const { role } = useAppSelector(firebaseSelector);
-  if (role === undefined && /.getautoclicker.com/.exec(window.location.href) !== null) {
+  if (role === undefined && /\.getautoclicker\.com/.exec(window.location.href) !== null) {
     return <GoogleAds />;
   }
   return null;


### PR DESCRIPTION
Potential fix for [https://github.com/Dhruv-Techapps/auto-clicker-auto-fill/security/code-scanning/1443](https://github.com/Dhruv-Techapps/auto-clicker-auto-fill/security/code-scanning/1443)

To fix the problem, we need to escape the dot (`.`) in the regular expression to ensure it matches a literal dot rather than any character. This will make the regular expression more precise and prevent unintended matches.

- Change the regular expression on line 7 from `/.getautoclicker.com/` to `/\.getautoclicker\.com/`.
- This change ensures that the regular expression will only match URLs that contain `.getautoclicker.com` as intended.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
