### PR TITLE
Potential fix for code scanning alert no. 1480: Exception text reinterpreted as HTML

### DIFF
--- a/packages/acf/events/src/lib/location-command.events.ts
+++ b/packages/acf/events/src/lib/location-command.events.ts
@@ -1,17 +1,8 @@
-import { SystemError } from '@dhruv-techapps/core-common';
+import { sanitizeUrl, SystemError } from '@dhruv-techapps/core-common';
 import { ACTION_I18N_TITLE } from '.';
 import CommonEvents from './common.events';
 
 const LOCATION_COMMANDS = ['reload', 'href', 'replace', 'open', 'close', 'focus', 'blur', 'print', 'stop', 'moveBy', 'moveTo'];
-
-const sanitizeUrl = (url: string): string | null => {
-  try {
-    const parsedUrl = new URL(url, window.location.origin);
-    return parsedUrl.href;
-  } catch {
-    return null;
-  }
-};
 
 export const LocationCommandEvents = (() => {
   const execCommand = (commands: Array<string | Event>, value: string) => {
@@ -21,16 +12,11 @@ export const LocationCommandEvents = (() => {
           window.location.reload();
           break;
         case 'href': {
-          const sanitizedValue = sanitizeUrl(value.split('::')[2]);
-          if (sanitizedValue) {
-            window.location.href = sanitizedValue;
-          } else {
-            console.error('Invalid URL provided for href command');
-          }
+          window.location.href = sanitizeUrl(value.split('::')[2]);
           break;
         }
         case 'replace':
-          window.location.replace(value.split('::')[2]);
+          window.location.replace(sanitizeUrl(value.split('::')[2]));
           break;
         case 'focus':
           window.focus();

--- a/packages/acf/events/src/lib/location-command.events.ts
+++ b/packages/acf/events/src/lib/location-command.events.ts
@@ -4,6 +4,15 @@ import CommonEvents from './common.events';
 
 const LOCATION_COMMANDS = ['reload', 'href', 'replace', 'open', 'close', 'focus', 'blur', 'print', 'stop', 'moveBy', 'moveTo'];
 
+const sanitizeUrl = (url: string): string | null => {
+  try {
+    const parsedUrl = new URL(url, window.location.origin);
+    return parsedUrl.href;
+  } catch {
+    return null;
+  }
+};
+
 export const LocationCommandEvents = (() => {
   const execCommand = (commands: Array<string | Event>, value: string) => {
     commands.forEach((command) => {
@@ -11,9 +20,15 @@ export const LocationCommandEvents = (() => {
         case 'reload':
           window.location.reload();
           break;
-        case 'href':
-          window.location.href = value.split('::')[2];
+        case 'href': {
+          const sanitizedValue = sanitizeUrl(value.split('::')[2]);
+          if (sanitizedValue) {
+            window.location.href = sanitizedValue;
+          } else {
+            console.error('Invalid URL provided for href command');
+          }
           break;
+        }
         case 'replace':
           window.location.replace(value.split('::')[2]);
           break;

--- a/packages/core/common/src/lib/utilities/url.ts
+++ b/packages/core/common/src/lib/utilities/url.ts
@@ -8,3 +8,12 @@ export function getParameterByName(name: string, url: string) {
   if (!results[2]) return '';
   return decodeURIComponent(results[2].replace(/\+/g, ' '));
 }
+
+export const sanitizeUrl = (url: string): string => {
+  try {
+    const parsedUrl = new URL(url, window.location.origin);
+    return parsedUrl.href;
+  } catch {
+    throw new Error('Invalid URL provided for href command');
+  }
+};


### PR DESCRIPTION
Potential fix for [https://github.com/Dhruv-Techapps/auto-clicker-auto-fill/security/code-scanning/1480](https://github.com/Dhruv-Techapps/auto-clicker-auto-fill/security/code-scanning/1480)

To fix the issue, we need to ensure that the `value.split('::')[2]` is properly sanitized or validated before being used to set `window.location.href`. This can be achieved by:
1. Validating the extracted value to ensure it conforms to expected patterns (e.g., a valid URL).
2. Escaping any potentially dangerous characters to prevent XSS or other injection attacks.
3. Using a library like `DOMPurify` for sanitization if the value is expected to contain HTML or other complex content.

The fix will involve:
- Adding a utility function to validate or sanitize the extracted value.
- Replacing the direct use of `value.split('::')[2]` with a sanitized version.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
