### PR TITLE
Potential fix for code scanning alert no. 1500: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-discord.yml
+++ b/.github/workflows/release-discord.yml
@@ -1,5 +1,8 @@
 name: Notify Discord on Release
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/Dhruv-Techapps/auto-clicker-auto-fill/security/code-scanning/1500](https://github.com/Dhruv-Techapps/auto-clicker-auto-fill/security/code-scanning/1500)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only reads release information and does not modify repository contents, the `contents: read` permission is sufficient. This limits the `GITHUB_TOKEN` to read-only access, adhering to the principle of least privilege.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or specifically to the `notify-discord` job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
